### PR TITLE
Revert BaGetter NUGET_SOURCE integration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Capture NUGET_SOURCE from environment
-      run: echo "NUGET_SOURCE_VALUE=${NUGET_SOURCE:-}" >> $GITHUB_ENV
-      shell: bash
-
     - name: Docker build (Attempt 1)
       id: build_1
       continue-on-error: true
@@ -36,7 +32,7 @@ runs:
         echo "--- End Debug Info ---"
         
         cd ${{ inputs.working-directory }}
-        docker build --build-arg NUGET_SOURCE=${{ env.NUGET_SOURCE_VALUE }} --target ${{ inputs.docker-file-target }} -f ${{ inputs.docker-file }} .
+        docker build --target ${{ inputs.docker-file-target }} -f ${{ inputs.docker-file }} .
       shell: bash
 
     - name: Docker build (Attempt 2)
@@ -58,7 +54,7 @@ runs:
         echo "--- End Debug Info ---"
         
         cd ${{ inputs.working-directory }}
-        docker build --build-arg NUGET_SOURCE=${{ env.NUGET_SOURCE_VALUE }} --target ${{ inputs.docker-file-target }} -f ${{ inputs.docker-file }} .
+        docker build --target ${{ inputs.docker-file-target }} -f ${{ inputs.docker-file }} .
       shell: bash
 
     - name: Docker build (Attempt 3)
@@ -79,5 +75,5 @@ runs:
         echo "--- End Debug Info ---"
         
         cd ${{ inputs.working-directory }}
-        docker build --build-arg NUGET_SOURCE=${{ env.NUGET_SOURCE_VALUE }} --target ${{ inputs.docker-file-target }} -f ${{ inputs.docker-file }} .
+        docker build --target ${{ inputs.docker-file-target }} -f ${{ inputs.docker-file }} .
       shell: bash


### PR DESCRIPTION
## Summary

This PR reverts the BaGetter NUGET_SOURCE integration introduced in v1.2, returning to v1.1 behavior.

## Changes Made

- **Removed** the "Capture NUGET_SOURCE from environment" step
- **Removed** `--build-arg NUGET_SOURCE` from all three Docker build attempts
- Builds will now use nuget.org directly instead of attempting to use BaGetter

## Rationale

While BaGetter provided a ~15% build time improvement, the maintenance overhead and complexity do not justify the benefit. Reverting to direct nuget.org access simplifies the build process and reduces potential points of failure.

## Version

Tagged as **v1.3**

## Migration Path

- Workflows using `@v1.2` will continue to use BaGetter integration
- Update workflow references to `@v1.3` to adopt this change
- Or use `@v1` to automatically pick up the latest v1.x version

## Testing

- YAML syntax verified
- All NUGET_SOURCE references removed
- Action should build Docker images successfully without the BaGetter build argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration by removing unused environment variable handling in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->