### PR TITLE
Simplify Docker build using docker/build-push-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Pull Request Build"
-description: "Will run a docker build to the given target (usually either the build target or test target, depending on if the project has any unit test)"
+description: "Build Docker image to specified target for pull request validation"
 inputs:
   working-directory:
     description: 'The path to the working directory'
@@ -14,66 +14,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Docker build (Attempt 1)
-      id: build_1
-      continue-on-error: true
-      run: |
-        echo "--- Debug Info for Attempt 1 ---"
-        echo "Current directory: $(pwd)"
-        echo "Working directory: ${{ inputs.working-directory }}"
-        echo "Dockerfile path: ${{ inputs.docker-file }}"
-        echo "Docker build target: ${{ inputs.docker-file-target }}"
-        echo "Listing contents of current directory:"
-        ls -la
-        echo "Listing contents of working directory:"
-        ls -la ${{ inputs.working-directory }}
-        echo "Docker version:"
-        docker --version
-        echo "--- End Debug Info ---"
-        
-        cd ${{ inputs.working-directory }}
-        docker build --target ${{ inputs.docker-file-target }} -f ${{ inputs.docker-file }} .
-      shell: bash
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
-    - name: Docker build (Attempt 2)
-      id: build_2
-      if: steps.build_1.outcome == 'failure'
-      continue-on-error: true
-      run: |
-        echo "--- Debug Info for Attempt 2 ---"
-        echo "Current directory: $(pwd)"
-        echo "Working directory: ${{ inputs.working-directory }}"
-        echo "Dockerfile path: ${{ inputs.docker-file }}"
-        echo "Docker build target: ${{ inputs.docker-file-target }}"
-        echo "Listing contents of current directory:"
-        ls -la
-        echo "Listing contents of working directory:"
-        ls -la ${{ inputs.working-directory }}
-        echo "Docker version:"
-        docker --version
-        echo "--- End Debug Info ---"
-        
-        cd ${{ inputs.working-directory }}
-        docker build --target ${{ inputs.docker-file-target }} -f ${{ inputs.docker-file }} .
-      shell: bash
-
-    - name: Docker build (Attempt 3)
-      id: build_3
-      if: steps.build_2.outcome == 'failure'
-      run: |
-        echo "--- Debug Info for Attempt 3 ---"
-        echo "Current directory: $(pwd)"
-        echo "Working directory: ${{ inputs.working-directory }}"
-        echo "Dockerfile path: ${{ inputs.docker-file }}"
-        echo "Docker build target: ${{ inputs.docker-file-target }}"
-        echo "Listing contents of current directory:"
-        ls -la
-        echo "Listing contents of working directory:"
-        ls -la ${{ inputs.working-directory }}
-        echo "Docker version:"
-        docker --version
-        echo "--- End Debug Info ---"
-        
-        cd ${{ inputs.working-directory }}
-        docker build --target ${{ inputs.docker-file-target }} -f ${{ inputs.docker-file }} .
-      shell: bash
+    - name: Build Docker image for testing
+      uses: docker/build-push-action@v6
+      with:
+        context: ${{ inputs.working-directory }}
+        file: ${{ inputs.working-directory }}/${{ inputs.docker-file }}
+        target: ${{ inputs.docker-file-target }}
+        push: false
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
Simplify action-pr by replacing custom retry logic and verbose debug logging with clean `docker/build-push-action` implementation, matching the pattern used in action-release.

## Changes

### Before (79 lines)
- 3 retry attempts with `continue-on-error`
- Verbose debug output on every attempt (pwd, ls, docker version, etc.)
- Manual `cd` and `docker build` commands
- No build caching

### After (29 lines) 
- Clean implementation using `docker/build-push-action@v6`
- Uses `docker/setup-buildx-action@v3` for better performance
- GitHub Actions cache (`type=gha`) for faster subsequent builds
- `push: false` - No registry push (PR validation only)
- `load: true` - Image available locally if needed

## Benefits

1. **Consistency**: Now matches action-release pattern
2. **Maintainability**: 50 lines removed, simpler to understand
3. **Performance**: GitHub Actions cache speeds up builds
4. **Better errors**: Buildx provides clearer error messages
5. **No unnecessary retries**: If build fails, fail fast with clear error

## Why Remove Retries?

The retry logic was likely added to work around transient network issues, but:
- Modern Docker/Buildx is more reliable
- GHA cache reduces network dependencies  
- If a build legitimately fails, retrying 3x just wastes time
- Better to fail fast and show clear error message

## Testing

This will affect all repositories using action-pr for PR builds. After merge:
- PR builds will use Buildx
- Builds will be cached between runs
- Build output will be cleaner (no debug spam)